### PR TITLE
Send payment_processor and payment_processor_id to Quaderno

### DIFF
--- a/classes/class-wc-qd-credit-manager.php
+++ b/classes/class-wc-qd-credit-manager.php
@@ -42,7 +42,7 @@ class WC_QD_Credit_Manager {
 			'tag_list' => implode( ',', $invoice->tag_list ),
 			'processor' => 'woocommerce',
 			'processor_id' => $order->get_id(),
-			'payment_method' => self::get_payment_method($order->get_id()),
+			'payment_method' => self::get_payment_method($order),
 			'document_id' => $invoice_id,
 			'custom_metadata' => array( 'processor_url' => $order->get_edit_order_url() )
 		);
@@ -85,8 +85,8 @@ class WC_QD_Credit_Manager {
 	 *
 	 * @param $order_id
 	 */
-	public function get_payment_method( $order_id ) {
-		$payment_id = get_post_meta( $order_id, '_payment_method', true );
+	public function get_payment_method( $order ) {
+		$payment_id = $order->get_payment_method();;
 		$method = '';
 		switch( $payment_id ) {
 			case 'bacs':

--- a/classes/class-wc-qd-credit-manager.php
+++ b/classes/class-wc-qd-credit-manager.php
@@ -43,6 +43,8 @@ class WC_QD_Credit_Manager {
 			'processor' => 'woocommerce',
 			'processor_id' => $order->get_id(),
 			'payment_method' => self::get_payment_method($order),
+      'payment_processor' => $order->get_payment_method(),
+      'payment_processor_id' => $order->get_transaction_id(),
 			'document_id' => $invoice_id,
 			'custom_metadata' => array( 'processor_url' => $order->get_edit_order_url() )
 		);

--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -34,6 +34,8 @@ class WC_QD_Invoice_Manager {
 			'processor' => 'woocommerce',
 			'processor_id' => $order_id,
 			'payment_method' => $this->get_payment_method($order_id),
+      			'payment_processor' => $this->get_payment_processor($order_id),
+      			'payment_processor_id' => $this->get_payment_processor_id($order_id),
 			'custom_metadata' => array( 'processor_url' => $order->get_edit_order_url() )
 		);
 
@@ -233,6 +235,34 @@ class WC_QD_Invoice_Manager {
 		}
 		return $method;
 	}
+
+  /**
+   * Get payment processor for Quaderno
+   *
+   * @param $order_id
+   */
+  public function get_payment_processor( $order_id ) {
+    $payment_id = get_post_meta( $order_id, '_payment_method', true );
+    $method = '';
+    switch( $payment_id ) {
+      case 'paypal':
+        $method = 'paypal';
+        break;
+      case 'stripe':
+        $method = 'stripe';
+        break;
+    }
+    return $method;
+  }
+
+  /**
+   * Get payment processor id for Quaderno
+   *
+   * @param $order_id
+   */
+  public function get_payment_processor_id( $order_id ) {
+    return get_post_meta( $order_id, '_transaction_id', true );
+  }
 	
 	public function get_tax_location( $order ) {
 		$tax_based_on = get_option( 'woocommerce_tax_based_on' );

--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -34,8 +34,8 @@ class WC_QD_Invoice_Manager {
 			'processor' => 'woocommerce',
 			'processor_id' => $order_id,
 			'payment_method' => $this->get_payment_method($order_id),
-      			'payment_processor' => $this->get_payment_processor($order_id),
-      			'payment_processor_id' => $this->get_payment_processor_id($order_id),
+      			'payment_processor' => get_post_meta( $order_id, '_payment_method', true ),
+      			'payment_processor_id' => get_post_meta( $order_id, '_transaction_id', true ),
 			'custom_metadata' => array( 'processor_url' => $order->get_edit_order_url() )
 		);
 
@@ -235,34 +235,6 @@ class WC_QD_Invoice_Manager {
 		}
 		return $method;
 	}
-
-  /**
-   * Get payment processor for Quaderno
-   *
-   * @param $order_id
-   */
-  public function get_payment_processor( $order_id ) {
-    $payment_id = get_post_meta( $order_id, '_payment_method', true );
-    $method = '';
-    switch( $payment_id ) {
-      case 'paypal':
-        $method = 'paypal';
-        break;
-      case 'stripe':
-        $method = 'stripe';
-        break;
-    }
-    return $method;
-  }
-
-  /**
-   * Get payment processor id for Quaderno
-   *
-   * @param $order_id
-   */
-  public function get_payment_processor_id( $order_id ) {
-    return get_post_meta( $order_id, '_transaction_id', true );
-  }
 	
 	public function get_tax_location( $order ) {
 		$tax_based_on = get_option( 'woocommerce_tax_based_on' );

--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -33,9 +33,9 @@ class WC_QD_Invoice_Manager {
 			'notes' => $order->get_customer_note(),
 			'processor' => 'woocommerce',
 			'processor_id' => $order_id,
-			'payment_method' => $this->get_payment_method($order_id),
-      			'payment_processor' => get_post_meta( $order_id, '_payment_method', true ),
-      			'payment_processor_id' => get_post_meta( $order_id, '_transaction_id', true ),
+			'payment_method' => $this->get_payment_method($order),
+      'payment_processor' => $order->get_payment_method(),
+      'payment_processor_id' => $order->get_transaction_id(),
 			'custom_metadata' => array( 'processor_url' => $order->get_edit_order_url() )
 		);
 
@@ -211,8 +211,8 @@ class WC_QD_Invoice_Manager {
 	 *
 	 * @param $order_id
 	 */
-	public function get_payment_method( $order_id ) {
-		$payment_id = get_post_meta( $order_id, '_payment_method', true );
+	public function get_payment_method( $order ) {
+		$payment_id = $order->get_payment_method();
 		$method = '';
 		switch( $payment_id ) {
 			case 'bacs':


### PR DESCRIPTION
Quaderno needs information about how the payment was processed. We send that information using fields `payment_processor` and `payment_processor_id`