### PR TITLE
Always send contact billing info in invoice creation request  payload

### DIFF
--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -54,45 +54,44 @@ class WC_QD_Invoice_Manager {
 			$invoice_params['notes'] = esc_html__('EU VAT reverse charged', 'woocommerce-quaderno' );
 		}
 
-		$contact_id = get_user_meta( $order->get_user_id(), '_quaderno_contact', true );
-		if ( !empty( $contact_id ) ) {
-			$invoice_params['contact_id'] = $contact_id;
-		}
-		else {
-			if ( !empty( $order->get_billing_company() ) ) {
-				$kind = 'company';
-				$first_name = $order->get_billing_company();
-				$last_name = '';
-				$contact_name = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
-			} else {
-				$kind = 'person';
-				$first_name = empty( $order->get_billing_first_name() ) ? esc_html__('WooCommerce customer', 'woocommerce-quaderno' ) : $order->get_billing_first_name();
-				$last_name = $order->get_billing_last_name();
-				$contact_name = '';
-			}
+		if ( !empty( $order->get_billing_company() ) ) {
+      $kind = 'company';
+      $first_name = $order->get_billing_company();
+      $last_name = '';
+      $contact_name = $order->get_billing_first_name() . ' ' . $order->get_billing_last_name();
+    } else {
+      $kind = 'person';
+      $first_name = empty( $order->get_billing_first_name() ) ? esc_html__('WooCommerce customer', 'woocommerce-quaderno' ) : $order->get_billing_first_name();
+      $last_name = $order->get_billing_last_name();
+      $contact_name = '';
+    }
 
-			$state = $order->get_billing_state();
-			$country = $order->get_billing_country();
-			$states = WC()->countries->get_states( $country );
-			$full_state = ( !in_array( $country, array('US', 'CA') ) && isset( $states[ $state ] ) ) ? $states[ $state ] : $state;
+    $state = $order->get_billing_state();
+    $country = $order->get_billing_country();
+    $states = WC()->countries->get_states( $country );
+    $full_state = ( !in_array( $country, array('US', 'CA') ) && isset( $states[ $state ] ) ) ? $states[ $state ] : $state;
 
-			$invoice_params['contact'] = array(
-				'kind' => $kind,
-				'first_name' => $first_name,
-				'last_name' => $last_name,
-				'contact_name' => $contact_name,
-				'street_line_1' => $order->get_billing_address_1(),
-				'street_line_2' => $order->get_billing_address_2(),
-				'city' => $order->get_billing_city(),
-				'postal_code' => $order->get_billing_postcode(),
-				'region' => $full_state,
-				'country' => $country,
-				'email' => $order->get_billing_email(),
-				'phone_1' => $order->get_billing_phone(),
-				'vat_number' => $vat_number,
-				'tax_id' => $tax_id
-			);
-		}
+    $invoice_params['contact'] = array(
+      'kind' => $kind,
+      'first_name' => $first_name,
+      'last_name' => $last_name,
+      'contact_name' => $contact_name,
+      'street_line_1' => $order->get_billing_address_1(),
+      'street_line_2' => $order->get_billing_address_2(),
+      'city' => $order->get_billing_city(),
+      'postal_code' => $order->get_billing_postcode(),
+      'region' => $full_state,
+      'country' => $country,
+      'email' => $order->get_billing_email(),
+      'phone_1' => $order->get_billing_phone(),
+      'vat_number' => $vat_number,
+      'tax_id' => $tax_id
+    );
+
+    $contact_id = get_user_meta( $order->get_user_id(), '_quaderno_contact', true );
+    if ( !empty( $contact_id ) ) {
+      $invoice_params['contact']['id'] = $contact_id;
+    }
 
 		// Let's create the invoice
 		$invoice = new QuadernoIncome($invoice_params);


### PR DESCRIPTION
When a buyer makes her first purchase in WC the billing information of that order is sent as the contact attributes to Quaderno.

In future purchases, only the Quaderno `contact_id` is sent. So for all the future orders of that buyer, the billing information of the first purchase will be used.

The plugin should always send the billing information of the order in case it has changed. If the WC user has the `quaderno_contact` metadata, we also send that ID so the Quaderno contact is updated with the billing information of the new order.