### PR TITLE
Use wordpress current_time function instead of PHP generic date function

### DIFF
--- a/classes/class-wc-qd-credit-manager.php
+++ b/classes/class-wc-qd-credit-manager.php
@@ -35,7 +35,7 @@ class WC_QD_Credit_Manager {
 		$invoice = QuadernoInvoice::find( $invoice_id );
 
 		$credit_params = array(
-			'issue_date' => date('Y-m-d'),
+			'issue_date' => current_time('Y-m-d'),
 			'contact_id' => $invoice->contact->id,
 			'currency' => $refund->get_currency(),
 			'po_number' => get_post_meta( $order->get_id(), '_order_number_formatted', true ) ?: $order->get_id(),

--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -27,7 +27,7 @@ class WC_QD_Invoice_Manager {
 		}
 
 		$invoice_params = array(
-			'issue_date' => date('Y-m-d'),
+			'issue_date' => current_time('Y-m-d'),
 			'currency' => $order->get_currency(),
 			'po_number' => get_post_meta( $order_id, '_order_number_formatted', true ) ?: $order_id,
 			'notes' => $order->get_customer_note(),


### PR DESCRIPTION
We need that the date is localized according to the configuration
that the user has set in his WP installation.

Using PHP date function we just get the server's datetime. The timezone
that is configured in the WP installation might be different.