### PR TITLE
Use the extra_rate tax that Quaderno calculates

### DIFF
--- a/classes/class-wc-qd-cart-manager.php
+++ b/classes/class-wc-qd-cart-manager.php
@@ -50,7 +50,9 @@ class WC_QD_Cart_Manager {
 					'id' => $id,
 					'product_type' => $tax_class,
 					'tax_name' => $tax->name,
-					'tax_rate' => $tax->rate );
+					'tax_rate' => $tax->rate, 
+          'tax_extra_name' => $tax->extra_name,
+          'tax_extra_rate' => $tax->extra_rate );
 			}
 		}
 

--- a/classes/class-wc-qd-checkout-vat.php
+++ b/classes/class-wc-qd-checkout-vat.php
@@ -41,7 +41,7 @@ class WC_QD_Checkout_Vat {
 				$tax_manager->add_product_tax_class( $item['id'], $item['product_type'] );
 
 				// Add the new tax rate for this transaction line
-				$tax_manager->add_tax_rate( $item['product_type'], $item['tax_rate'], $item['tax_name'] );
+				$tax_manager->add_tax_rate( $item['product_type'], $item['tax_rate'], $item['tax_name'], $item['tax_extra_rate'], $item['tax_extra_name'] );
 			}
 		}
 	}
@@ -157,7 +157,7 @@ class WC_QD_Checkout_Vat {
 				$tax = WC_QD_Calculate_Tax::calculate($tax_class, $country);
 
 				$tax_manager->add_product_tax_class( $item_id, $tax_class );
-				$tax_manager->add_tax_rate( $tax_class, $tax->rate, $tax->name );
+				$tax_manager->add_tax_rate( $tax_class, $tax->rate, $tax->name, $tax->extra_rate, $tax->extra_name );
 				$items['order_item_tax_class'][ $item_id ] = $tax_manager->clean_tax_class( $tax_class );
 			}
 

--- a/classes/class-wc-qd-credit-manager.php
+++ b/classes/class-wc-qd-credit-manager.php
@@ -79,7 +79,16 @@ class WC_QD_Credit_Manager {
 			'tax_1_city' => $item->tax_1_city,
 			'tax_1_county_code' => $item->tax_1_county_code,
 			'tax_1_city_code' => $item->tax_1_city_code,
-			'tax_1_transaction_type' => $item->tax_1_transaction_type
+			'tax_1_transaction_type' => $item->tax_1_transaction_type,
+      'tax_2_name' => $item->tax_2_name,
+      'tax_2_rate' => $item->tax_2_rate,
+      'tax_2_country' => $item->tax_2_country,
+      'tax_2_region' => $item->tax_2_region,
+      'tax_2_county' => $item->tax_2_county,
+      'tax_2_city' => $item->tax_2_city,
+      'tax_2_county_code' => $item->tax_2_county_code,
+      'tax_2_city_code' => $item->tax_2_city_code,
+      'tax_2_transaction_type' => $item->tax_2_transaction_type
 		));
 		$credit->addItem( $new_item );
 

--- a/classes/class-wc-qd-invoice-manager.php
+++ b/classes/class-wc-qd-invoice-manager.php
@@ -138,6 +138,7 @@ class WC_QD_Invoice_Manager {
 			if ( true === WC_QD_Tax_Id_Field::is_valid( $tax_id, $order->get_billing_country() ) ) {
 				$tax->name = '';
 				$tax->rate = 0;
+        $tax->extra_rate = 0;
 			}
 
 			if ( true == in_array( $tax_class, array('eservice', 'ebook') )) {
@@ -148,21 +149,36 @@ class WC_QD_Invoice_Manager {
 			$total = $order->get_line_total($item, true);
 			$discount_rate = $subtotal == 0  ? 0 : round( ( $subtotal -  $total ) / $subtotal * 100, 0 );
 
-			$new_item = new QuadernoDocumentItem(array(
-				'description' => $item->get_name(),
-				'quantity' => $item->get_quantity(),
-				'total_amount' => round( $total * $exchange_rate, wc_get_price_decimals() ),
-				'discount_rate' => $discount_rate,
-				'tax_1_name' => $tax->name,
-				'tax_1_rate' => $tax->rate,
-				'tax_1_country' => $tax->country,
-				'tax_1_region' => $tax->region,
-				'tax_1_county' => $tax->county,
-				'tax_1_city' => $tax->city,
-				'tax_1_county_code' => $tax->county_tax_code,
-				'tax_1_city_code' => $tax->city_tax_code,
-				'tax_1_transaction_type' => $tax->transaction_type
-			));
+      $item_data = array(
+        'description' => $item->get_name(),
+        'quantity' => $item->get_quantity(),
+        'total_amount' => round( $total * $exchange_rate, wc_get_price_decimals() ),
+        'discount_rate' => $discount_rate,
+        'tax_1_name' => $tax->name,
+        'tax_1_rate' => $tax->rate,
+        'tax_1_country' => $tax->country,
+        'tax_1_region' => $tax->region,
+        'tax_1_county' => $tax->county,
+        'tax_1_city' => $tax->city,
+        'tax_1_county_code' => $tax->county_tax_code,
+        'tax_1_city_code' => $tax->city_tax_code,
+        'tax_1_transaction_type' => $tax->transaction_type
+      );
+
+      if( !empty($tax->extra_rate) ){
+        $item_data['tax_2_name'] = $tax->extra_name;
+        $item_data['tax_2_rate'] = $tax->extra_rate;
+        $item_data['tax_2_country'] = $tax->country;
+        $item_data['tax_2_region'] = $tax->region;
+        $item_data['tax_2_county'] = $tax->county;
+        $item_data['tax_2_city'] = $tax->city;
+        $item_data['tax_2_county_code'] = $tax->county_tax_code;
+        $item_data['tax_2_city_code'] = $tax->city_tax_code;
+        $item_data['tax_2_transaction_type'] = $tax->transaction_type;
+      }
+
+
+			$new_item = new QuadernoDocumentItem( $item_data );
 
 			// Store the product code
 			$product = wc_get_product( $item->get_product_id() );
@@ -188,25 +204,40 @@ class WC_QD_Invoice_Manager {
 			if ( true === WC_QD_Tax_Id_Field::is_valid( $tax_id, $order->get_billing_country() ) ) {
 				$tax->name = '';
 				$tax->rate = 0;
+        $tax->extra_rate = 0;
 			}
 
 			$shipping_tax = $order->get_shipping_tax();
 			$shipping_total += $shipping_tax;
+      
+      $item_data = array(
+        'description' => esc_html__('Shipping', 'woocommerce-quaderno' ),
+        'quantity' => 1,
+        'total_amount' => round( $shipping_total * $exchange_rate, 2),
+        'tax_1_name' => $tax->name,
+        'tax_1_rate' => $tax->rate,
+        'tax_1_country' => $tax->country,
+        'tax_1_region' => $tax->region,
+        'tax_1_county' => $tax->county,
+        'tax_1_city' => $tax->city,
+        'tax_1_county_code' => $tax->county_tax_code,
+        'tax_1_city_code' => $tax->city_tax_code,
+        'tax_1_transaction_type' => $tax->transaction_type
+      );
 
-			$new_item = new QuadernoDocumentItem(array(
-				'description' => esc_html__('Shipping', 'woocommerce-quaderno' ),
-				'quantity' => 1,
-				'total_amount' => round( $shipping_total * $exchange_rate, 2),
-				'tax_1_name' => $tax->name,
-				'tax_1_rate' => $tax->rate,
-				'tax_1_country' => $tax->country,
-				'tax_1_region' => $tax->region,
-				'tax_1_county' => $tax->county,
-				'tax_1_city' => $tax->city,
-				'tax_1_county_code' => $tax->county_tax_code,
-				'tax_1_city_code' => $tax->city_tax_code,
-				'tax_1_transaction_type' => $tax->transaction_type
-			));
+      if( !empty($tax->extra_rate) ){
+        $item_data['tax_2_name'] = $tax->extra_name;
+        $item_data['tax_2_rate'] = $tax->extra_rate;
+        $item_data['tax_2_country'] = $tax->country;
+        $item_data['tax_2_region'] = $tax->region;
+        $item_data['tax_2_county'] = $tax->county;
+        $item_data['tax_2_city'] = $tax->city;
+        $item_data['tax_2_county_code'] = $tax->county_tax_code;
+        $item_data['tax_2_city_code'] = $tax->city_tax_code;
+        $item_data['tax_2_transaction_type'] = $tax->transaction_type;
+      }
+			
+      $new_item = new QuadernoDocumentItem($item_data);
 			$invoice->addItem( $new_item );
 		}
 
@@ -219,24 +250,39 @@ class WC_QD_Invoice_Manager {
 			if ( true === WC_QD_Tax_Id_Field::is_valid( $tax_id, $order->get_billing_country() ) ) {
 				$tax->name = '';
 				$tax->rate = 0;
+        $tax->extra_rate = 0;
 			}
 
 			$fee_total = $fee['total'] + $fee['total_tax'];
 
-			$new_item = new QuadernoDocumentItem(array(
-				'description' => $fee->get_name(),
-				'quantity' => 1,
-				'total_amount' => round( $fee_total * $exchange_rate, 2),
-				'tax_1_name' => $tax->name,
-				'tax_1_rate' => $tax->rate,
-				'tax_1_country' => $tax->country,
-				'tax_1_region' => $tax->region,
-				'tax_1_county' => $tax->county,
-				'tax_1_city' => $tax->city,
-				'tax_1_county_code' => $tax->county_tax_code,
-				'tax_1_city_code' => $tax->city_tax_code,
-				'tax_1_transaction_type' => $tax->transaction_type
-			));
+      $item_data = array(
+        'description' => $fee->get_name(),
+        'quantity' => 1,
+        'total_amount' => round( $fee_total * $exchange_rate, 2),
+        'tax_1_name' => $tax->name,
+        'tax_1_rate' => $tax->rate,
+        'tax_1_country' => $tax->country,
+        'tax_1_region' => $tax->region,
+        'tax_1_county' => $tax->county,
+        'tax_1_city' => $tax->city,
+        'tax_1_county_code' => $tax->county_tax_code,
+        'tax_1_city_code' => $tax->city_tax_code,
+        'tax_1_transaction_type' => $tax->transaction_type
+      );
+
+      if( !empty($tax->extra_rate) ){
+        $item_data['tax_2_name'] = $tax->extra_name;
+        $item_data['tax_2_rate'] = $tax->extra_rate;
+        $item_data['tax_2_country'] = $tax->country;
+        $item_data['tax_2_region'] = $tax->region;
+        $item_data['tax_2_county'] = $tax->county;
+        $item_data['tax_2_city'] = $tax->city;
+        $item_data['tax_2_county_code'] = $tax->county_tax_code;
+        $item_data['tax_2_city_code'] = $tax->city_tax_code;
+        $item_data['tax_2_transaction_type'] = $tax->transaction_type;
+      }
+
+			$new_item = new QuadernoDocumentItem($item_data);
 			$invoice->addItem( $new_item );
 		}
 

--- a/classes/class-wc-qd-tax-manager.php
+++ b/classes/class-wc-qd-tax-manager.php
@@ -158,8 +158,13 @@ class WC_QD_Tax_Manager {
 	 *
 	 * @return bool
 	 */
-	public function add_tax_rate( $tax_class, $rate, $label ) {
+	public function add_tax_rate( $tax_class, $rate, $label, $extra_rate=null, $extra_label=null ) {
 		$clean_slug = $this->clean_tax_class( $tax_class );
+
+    if( !empty($extra_rate) && !empty($extra_label)){
+      $rate += $extra_rate;
+      $label = $label. ' + ' .$extra_label;
+    }
 
 		if ( ! isset( $this->tax_rates[ $clean_slug ] ) ) {
 			$this->tax_rates[ $clean_slug ] = array(


### PR DESCRIPTION
QuadernoWoocommerce plugin is only using the main tax returned by Quaderno's Taxes/calculate API method.

The extra tax will be used:

1) In the checkout process when the taxes are recalculated based on the address filled out by the buyer.

2) When the document is created in Quaderno after a successful order or a refund.