### PR TITLE
Fix tax ID validation caching when validation service is down

### DIFF
--- a/classes/class-wc-qd-tax-id-field.php
+++ b/classes/class-wc-qd-tax-id-field.php
@@ -116,8 +116,13 @@ class WC_QD_Tax_Id_Field {
     $slug = 'vat_number_' . md5( implode( $params ) );
 
     if ( false === ( $valid_number = get_transient( $slug ) ) ) {
-      $valid_number = (int) QuadernoTaxId::validate( $params );
-      set_transient( $slug, $valid_number, 4 * WEEK_IN_SECONDS );
+      $validation_result = QuadernoTaxId::validate( $params );
+      $valid_number = (int) $validation_result;
+
+      // Cache the result, unless the tax ID validation service was down.
+      if ( !is_null($validation_result) ) {
+        set_transient( $slug, $valid_number, 4 * WEEK_IN_SECONDS );
+      }
     }
 
     return $valid_number == 1 && $country != $woocommerce->countries->get_base_country();


### PR DESCRIPTION
A tax ID validation may have 3 results:

- true, meaning that the ID is valid
- false, meaning that the ID is invalid
- null, meaning that the validation service (such as VIES) is down

Merits (or lack of thereof) of this tri-boolean aside, we were always caching the result, leading to tax IDs not being treated as valid following VIES downtime/issues. Thus, lets not cache the result when it is null.

PS: @polimorfico I didn't have permissions to push to this repository, and had to fork it. Can you please review the permissions?