### PR TITLE
Fix tax_id not present warning

### DIFF
--- a/classes/class-wc-qd-checkout-vat.php
+++ b/classes/class-wc-qd-checkout-vat.php
@@ -34,7 +34,7 @@ class WC_QD_Checkout_Vat {
 			$shipping_state = WC()->customer->get_shipping_state();
 			$shipping_postcode = WC()->customer->get_shipping_postcode();
 			$shipping_city = WC()->customer->get_shipping_city();
-			$tax_id = sanitize_text_field( 'billing' === $tax_based_on ? $_POST['tax_id'] : '' );
+			$tax_id = sanitize_text_field( 'billing' === $tax_based_on ? (isset($_POST['tax_id']) ? $_POST['tax_id'] : '') : '' );
 			
 			// The cart manager
 			$cart_manager = new WC_QD_Cart_Manager( $shipping_country, $shipping_state, $shipping_postcode, $shipping_city, $tax_id );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: polimorfico
 Tags: woocommerce, tax, taxes, sales tax, vat, gst, vatmoss, vat moss, vat oss, billing, invoices, receipts, credit notes
 Requires at least: 4.6
 Tested up to: 6.1
-Stable tag: 2.1.16
+Stable tag: 2.1.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -70,6 +70,9 @@ We offer simple, transaction-based pricing that scales with your business. [Quad
 4. Example of an invoice
 
 == Changelog ==
+
+= 2.1.17 – March 20, 2023 =
+* Fix: warning in cart page when tax_id parameter not set
 
 = 2.1.16 – March 15, 2023 =
 * New: we now calculate taxes in the shopping cart

--- a/woocommerce-quaderno.php
+++ b/woocommerce-quaderno.php
@@ -4,7 +4,7 @@
  * Plugin Name: WooCommerce Quaderno
  * Plugin URI: https://wordpress.org/plugins/woocommerce-quaderno/
  * Description:  Automatically calculate tax rates & create instant tax reports for your WooCommerce store.
- * Version: 2.1.16
+ * Version: 2.1.17
  * Author: Quaderno
  * Author URI: https://quaderno.io/integrations/woocommerce/?utm_source=wordpress&utm_campaign=woocommerce
  * WC requires at least: 3.2.0


### PR DESCRIPTION
Fixes a php warning when displaying the cart if `tax_id` key is not set in $_POST variable